### PR TITLE
Set background color on scrollview subviews - this allows for real-time ...

### DIFF
--- a/V8HorizontalPickerView.m
+++ b/V8HorizontalPickerView.m
@@ -228,7 +228,10 @@
 - (void)setBackgroundColor:(UIColor *)newColor {
 	[super setBackgroundColor:newColor];
 	_scrollView.backgroundColor = newColor;
-	// TODO: set all subviews as well?
+	
+    for (UIView *view in [_scrollView subviews]) {
+        view.backgroundColor = newColor;
+    }
 }
 
 - (void)setIndicatorPosition:(V8HorizontalPickerIndicatorPosition)position {


### PR DESCRIPTION
Set background color on scrollview subviews - this allows for real-time color changes from within a UIViewController. Without this change, the subviews remain in the old background color until the scrollview is scrolled
